### PR TITLE
Stricten matchers from `==`(equal) to `===`(identical), and add associative array matchers

### DIFF
--- a/hamcrest-php/hamcrest/Hamcrest.php
+++ b/hamcrest-php/hamcrest/Hamcrest.php
@@ -43,7 +43,7 @@ function anArray(/* args... */)
 
 /**
  * Evaluates to true if any item in an array satisfies the given matcher.
- * 
+ *
  * @param mixed $item as a {@link Hamcrest_Matcher} or a value.
  */
 function hasItemInArray($item)
@@ -54,7 +54,7 @@ function hasItemInArray($item)
 
 /**
  * Evaluates to true if any item in an array satisfies the given matcher.
- * 
+ *
  * @param mixed $item as a {@link Hamcrest_Matcher} or a value.
  */
 function hasValue($item)
@@ -66,31 +66,38 @@ function hasValue($item)
 /**
  * An array with elements that match the given matchers.
  */
-function arrayContainingInAnyOrder(/* args... */)
+function arrayContainingInAnyOrder(...$args)
 {
   require_once 'Hamcrest/Array/IsArrayContainingInAnyOrder.php';
-  $args = func_get_args();
-  return call_user_func_array(array('Hamcrest_Array_IsArrayContainingInAnyOrder', 'arrayContainingInAnyOrder'), $args);
+  return Hamcrest_Array_IsArrayContainingInAnyOrder::arrayContainingInAnyOrder(...$args);
 }
 
 /**
  * An array with elements that match the given matchers.
  */
-function containsInAnyOrder(/* args... */)
+function associativeArrayContainingSameItemsInAnyOrder(...$args)
+{
+  require_once 'Hamcrest/Array/IsAssociativeArrayContainingSameItemsInAnyOrder.php';
+  $args = func_get_args();
+  return Hamcrest_Array_IsAssociativeArrayContainingSameItemsInAnyOrder::associativeArrayContainingSameItemsInAnyOrder(...$args);
+}
+
+/**
+ * An array with elements that match the given matchers.
+ */
+function containsInAnyOrder(...$args)
 {
   require_once 'Hamcrest/Array/IsArrayContainingInAnyOrder.php';
-  $args = func_get_args();
-  return call_user_func_array(array('Hamcrest_Array_IsArrayContainingInAnyOrder', 'arrayContainingInAnyOrder'), $args);
+  return Hamcrest_Array_IsArrayContainingInAnyOrder::arrayContainingInAnyOrder($args);
 }
 
 /**
  * An array with elements that match the given matchers in the same order.
  */
-function arrayContaining(/* args... */)
+function arrayContaining(...$args)
 {
   require_once 'Hamcrest/Array/IsArrayContainingInOrder.php';
-  $args = func_get_args();
-  return call_user_func_array(array('Hamcrest_Array_IsArrayContainingInOrder', 'arrayContaining'), $args);
+  return Hamcrest_Array_IsArrayContainingInOrder::arrayContaining($args);
 }
 
 /**
@@ -105,7 +112,7 @@ function contains(/* args... */)
 
 /**
  * Evaluates to true if any key in an array matches the given matcher.
- * 
+ *
  * @param mixed $key as a {@link Hamcrest_Matcher} or a value.
  */
 function hasKeyInArray($key)
@@ -116,7 +123,7 @@ function hasKeyInArray($key)
 
 /**
  * Evaluates to true if any key in an array matches the given matcher.
- * 
+ *
  * @param mixed $key as a {@link Hamcrest_Matcher} or a value.
  */
 function hasKey($key)
@@ -145,7 +152,7 @@ function hasEntry($key, $value)
 
 /**
  * Does array size satisfy a given matcher?
- * 
+ *
  * @param int $size as a {@link Hamcrest_Matcher} or a value.
  */
 function arrayWithSize($size)
@@ -268,7 +275,7 @@ function describedAs(/* args... */)
 /**
  * @param Hamcrest_Matcher $itemMatcher
  *   A matcher to apply to every element in an array.
- * 
+ *
  * @return Hamcrest_Core_Every
  *   Evaluates to TRUE for a collection in which every item matches $itemMatcher
  */
@@ -290,7 +297,7 @@ function hasToString($matcher)
 /**
  * Decorates another Matcher, retaining the behavior but allowing tests
  * to be slightly more expressive.
- * 
+ *
  * For example:  assertThat($cheese, equalTo($smelly))
  *          vs.  assertThat($cheese, is(equalTo($smelly)))
  */
@@ -302,7 +309,7 @@ function is($value)
 
 /**
  * This matcher always evaluates to true.
- * 
+ *
  * @param string $description A meaningful string used when describing itself.
  */
 function anything($description = 'ANYTHING')
@@ -313,7 +320,7 @@ function anything($description = 'ANYTHING')
 
 /**
  * Test if the value is an array containing this matcher.
- * 
+ *
  * Example:
  * <pre>
  * assertThat(array('a', 'b'), hasItem(equalTo('b')));
@@ -331,7 +338,7 @@ function hasItem(/* args... */)
 /**
  * Test if the value is an array containing elements that match all of these
  * matchers.
- * 
+ *
  * Example:
  * <pre>
  * assertThat(array('a', 'b', 'c'), hasItems(equalTo('a'), equalTo('b')));
@@ -416,7 +423,7 @@ function notNullValue()
 
 /**
  * Creates a new instance of IsSame.
- * 
+ *
  * @param mixed $object
  *   The predicate evaluates to true only when the argument is
  *   this object.

--- a/hamcrest-php/hamcrest/Hamcrest/Array/FullyMatchingOnce.php
+++ b/hamcrest-php/hamcrest/Hamcrest/Array/FullyMatchingOnce.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ Copyright (c) 2009 hamcrest.org
+ */
+
+require_once 'Hamcrest/Description.php';
+
+class Hamcrest_Array_FullyMatchingOnce
+{
+
+  private $_elementMatchers;
+  private $_mismatchDescription;
+
+  public function __construct(array $elementMatchers,
+    Hamcrest_Description $mismatchDescription)
+  {
+    $this->_elementMatchers = $elementMatchers;
+    $this->_mismatchDescription = $mismatchDescription;
+  }
+
+  public function matches($item, $key = null) : bool
+  {
+    return $this->_isNotSurplus($item) && $this->_isMatched($item, $key);
+  }
+
+  public function isFinished($items) : bool
+  {
+    if (empty($this->_elementMatchers))
+    {
+      return true;
+    }
+
+    $this->_mismatchDescription
+         ->appendText('No item matches: ')->appendAssociativeArray('', ', ', '=', '', $this->_elementMatchers)
+         ->appendText(' in ')->appendValueList('[', ', ', ']', $items)
+         ;
+    return false;
+  }
+
+  // -- Private Methods
+
+  private function _isNotSurplus($item) : bool
+  {
+    if (empty($this->_elementMatchers))
+    {
+      $this->_mismatchDescription->appendText('Not matched: ')->appendValue($item);
+      return false;
+    }
+
+    return true;
+  }
+
+  private function _isMatched($item, $key) : bool
+  {
+    if ($key !== null && isset($this->_elementMatchers[$key]) && $this->_elementMatchers[$key]->matches($item))
+    {
+      unset($this->_elementMatchers[$key]);
+      return true;
+    }
+    $this->_mismatchDescription->appendText('Not matched: key=')->appendValue($key)->appendText(', value=')->appendValue($item);
+    return false;
+  }
+
+}

--- a/hamcrest-php/hamcrest/Hamcrest/Array/IsAssociativeArrayContainingSameItemsInAnyOrder.php
+++ b/hamcrest-php/hamcrest/Hamcrest/Array/IsAssociativeArrayContainingSameItemsInAnyOrder.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ Copyright (c) 2009 hamcrest.org
+ */
+
+require_once 'Hamcrest/TypeSafeDiagnosingMatcher.php';
+require_once 'Hamcrest/Description.php';
+require_once 'Hamcrest/Matcher.php';
+require_once 'Hamcrest/Util.php';
+require_once 'Hamcrest/Array/MatchingOnce.php';
+
+/**
+ * Matches if an array contains a set of items satisfying nested matchers.
+ */
+class Hamcrest_Array_IsAssociativeArrayContainingSameItemsInAnyOrder
+  extends Hamcrest_TypeSafeDiagnosingMatcher
+{
+
+  private $_elementMatchers;
+
+  public function __construct(array $elementMatchers)
+  {
+    parent::__construct(self::TYPE_ARRAY);
+
+    Hamcrest_Util::checkAllAreMatchers($elementMatchers);
+
+    $this->_elementMatchers = $elementMatchers;
+  }
+
+  protected function matchesSafelyWithDiagnosticDescription($array,
+    Hamcrest_Description $mismatchDescription)
+  {
+    $matching = new Hamcrest_Array_FullyMatchingOnce(
+      $this->_elementMatchers, $mismatchDescription
+    );
+
+    foreach ($array as $key => $element)
+    {
+      $isNumericKey = (int)((string)$key) === $key;
+      if (!$matching->matches($element, $isNumericKey ? null : $key))
+      {
+        return false;
+      }
+    }
+
+    return $matching->isFinished($array);
+  }
+
+  public function describeTo(Hamcrest_Description $description)
+  {
+    $description->appendAssociativeArray('[', ', ', '=', ']', $this->_elementMatchers)
+                ->appendText(' in any order, with strict comparison ')
+                ;
+  }
+
+  /**
+   * An array with elements that match the given matchers.
+   *
+   * @factory associativeArrayContainingSameItemsInAnyOrder ...
+   */
+  public static function associativeArrayContainingSameItemsInAnyOrder(/* args... */)
+  {
+    $args = func_get_args();
+    return new self(Hamcrest_Util::createMatcherArray($args));
+  }
+
+}

--- a/hamcrest-php/hamcrest/Hamcrest/BaseDescription.php
+++ b/hamcrest-php/hamcrest/Hamcrest/BaseDescription.php
@@ -13,19 +13,19 @@ require_once 'Hamcrest/Internal/SelfDescribingValue.php';
  */
 abstract class Hamcrest_BaseDescription implements Hamcrest_Description
 {
-  
+
   public function appendText($text)
   {
     $this->append($text);
     return $this;
   }
-  
+
   public function appendDescriptionOf(Hamcrest_SelfDescribing $value)
   {
     $value->describeTo($this);
     return $this;
   }
-  
+
   public function appendValue($value)
   {
     if (is_null($value))
@@ -66,7 +66,7 @@ abstract class Hamcrest_BaseDescription implements Hamcrest_Description
     }
     return $this;
   }
-  
+
   public function appendValueList($start, $separator, $end, $values)
   {
     $list = array();
@@ -74,48 +74,71 @@ abstract class Hamcrest_BaseDescription implements Hamcrest_Description
     {
       $list[] = new Hamcrest_Internal_SelfDescribingValue($v);
     }
-    
+
     $this->appendList($start, $separator, $end, $list);
     return $this;
   }
-  
+
   public function appendList($start, $separator, $end, $values)
   {
     $this->append($start);
-    
+
     $separate = false;
-    
+
     foreach ($values as $value)
     {
       /*if (!($value instanceof Hamcrest_SelfDescribing))
       {
         $value = new Hamcrest_Internal_SelfDescribingValue($value);
       }*/
-      
+
       if ($separate)
       {
         $this->append($separator);
       }
-      
+
       $this->appendDescriptionOf($value);
-      
+
       $separate = true;
     }
-    
+
     $this->append($end);
-    
+
     return $this;
   }
-  
+
+  public function appendAssociativeArray($start, $separator, $entryKeyValueSeparator, $end, $values)
+  {
+    $this->append($start);
+
+    $separate = false;
+
+    foreach ($values as $key => $value)
+    {
+      if ($separate)
+      {
+        $this->append($separator);
+      }
+
+      $this->appendValue($key)->append($keySeparator)->appendDescriptionOf($value);
+
+      $separate = true;
+    }
+
+    $this->append($end);
+
+    return $this;
+  }
+
   // -- Protected Methods
-  
+
   /**
    * Append the String <var>$str</var> to the description.
    */
   abstract protected function append($str);
-  
+
   // -- Private Methods
-  
+
   private function _toPhpSyntax($value)
   {
     $str = '"';
@@ -126,19 +149,19 @@ abstract class Hamcrest_BaseDescription implements Hamcrest_Description
         case '"':
           $str .= '\\"';
           break;
-        
+
         case "\t":
           $str .= '\\t';
           break;
-        
+
         case "\r":
           $str .= '\\r';
           break;
-        
+
         case "\n":
           $str .= '\\n';
           break;
-        
+
         default:
           $str .= $value[$i];
       }
@@ -146,5 +169,5 @@ abstract class Hamcrest_BaseDescription implements Hamcrest_Description
     $str .= '"';
     $this->append($str);
   }
-  
+
 }

--- a/hamcrest-php/hamcrest/Hamcrest/Description.php
+++ b/hamcrest-php/hamcrest/Hamcrest/Description.php
@@ -68,5 +68,19 @@ interface Hamcrest_Description
    * @return Hamcrest_Description
    */
   public function appendList($start, $separator, $end, $values);
+
+  /**
+   * Appends an associative array of {@link Hamcrest_SelfDescribing} objects to the
+   * description.
+   *
+   * @param string $start
+   * @param string $separator
+   * @param string $end
+   * @param array|IteratorAggregate|Iterator $values
+   *   must be instances of {@link Hamcrest_SelfDescribing}
+   *
+   * @return Hamcrest_Description
+   */
+  public function appendAssociativeArray($start, $separator, $entryKeyValueSeparator, $end, $values);
   
 }

--- a/hamcrest-php/hamcrest/Hamcrest/MatcherAssert.php
+++ b/hamcrest-php/hamcrest/Hamcrest/MatcherAssert.php
@@ -97,7 +97,6 @@ class Hamcrest_MatcherAssert
     self::$_count = 0;
   }
 
-
   /**
    * Performs the actual assertion logic.
    *

--- a/hamcrest-php/hamcrest/Hamcrest/NullDescription.php
+++ b/hamcrest-php/hamcrest/Hamcrest/NullDescription.php
@@ -37,7 +37,12 @@ class Hamcrest_NullDescription implements Hamcrest_Description
   {
     return $this;
   }
-  
+
+  public function appendAssociativeArray($start, $separator, $entryKeyValueSeparator, $end, $values)
+  {
+    return $this;
+  }
+
   public function __toString()
   {
     return '';

--- a/hamcrest-php/hamcrest/Hamcrest/Util.php
+++ b/hamcrest-php/hamcrest/Hamcrest/Util.php
@@ -70,7 +70,8 @@ class Hamcrest_Util
     {
       if (!($item instanceof Hamcrest_Matcher))
       {
-        $item = Hamcrest_Core_IsEqual::equalTo($item);
+        // Enable strict matching, to avoid confusing between int and string (e.g. `"2"` and `2`)
+        $item = Hamcrest_Core_IsIdentical::identicalTo($item);
       }
     }
 

--- a/hamcrest-php/tests/Hamcrest/Collection/IsEmptyTraversableTest.php
+++ b/hamcrest-php/tests/Hamcrest/Collection/IsEmptyTraversableTest.php
@@ -37,7 +37,6 @@ class Hamcrest_Traversable_IsEmptyTraversableTest
     $this->assertDescription('an empty traversable', emptyTraversable());
   }
 
-
   public function testNonEmptyDoesNotMatchNull()
   {
     $this->assertDoesNotMatch(nonEmptyTraversable(), null,

--- a/hamcrest-php/tests/Hamcrest/Core/AnyOfTest.php
+++ b/hamcrest-php/tests/Hamcrest/Core/AnyOfTest.php
@@ -45,7 +45,6 @@ class Hamcrest_Core_AnyOfTest extends Hamcrest_AbstractMatcherTest
     );
   }
 
-
   public function testNoneOfEvaluatesToTheLogicalDisjunctionOfTwoOtherMatchers()
   {
     assertThat('good', not(noneOf('bad', 'good')));

--- a/hamcrest-php/tests/Hamcrest/Text/IsEmptyStringTest.php
+++ b/hamcrest-php/tests/Hamcrest/Text/IsEmptyStringTest.php
@@ -45,7 +45,6 @@ class Hamcrest_Text_IsEmptyStringTest extends Hamcrest_AbstractMatcherTest
     $this->assertDescription('an empty string', emptyString());
   }
 
-
   public function testEmptyOrNullMatchesNull()
   {
     $this->assertMatches(nullOrEmptyString(), null, 'null');
@@ -65,7 +64,6 @@ class Hamcrest_Text_IsEmptyStringTest extends Hamcrest_AbstractMatcherTest
   {
     $this->assertDescription('(null or an empty string)', nullOrEmptyString());
   }
-
 
   public function testNonEmptyDoesNotMatchNull()
   {

--- a/hamcrest-php/tests/Hamcrest/UtilTest.php
+++ b/hamcrest-php/tests/Hamcrest/UtilTest.php
@@ -20,7 +20,6 @@ class Hamcrest_UtilTest extends PHPUnit_Framework_TestCase
     $this->assertTrue($matcher->matches('foo'));
   }
 
-
   public function testCheckAllAreMatchersAcceptsMatchers()
   {
     Hamcrest_Util::checkAllAreMatchers(array(
@@ -39,7 +38,6 @@ class Hamcrest_UtilTest extends PHPUnit_Framework_TestCase
       'foo',
     ));
   }
-
 
   private function callAndAssertCreateMatcherArray($items)
   {

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -346,14 +346,14 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 Failed asserting that method Foo was called 1 times - actually called 0 times.
 Wanted call:
 Array &0 (
-	0 => Array &1 (
-		'foo' => '2'
-	)
+    0 => Array &1 (
+        'foo' => '2'
+    )
 )Calls:
 Array &0 (
-	0 => Array &1 (
-		'foo' => 2
-	)
+    0 => Array &1 (
+        'foo' => 2
+    )
 )
 EOT;
 			$this->assertSame($expectedMessage, $actualMessage, 'Should use SebastianBergmann\Exporter to print a clear description of the error');


### PR DESCRIPTION
Also, fix whitespace in string literal for test expectation