### PR TITLE
Throw a TypeError for mocks with invalid return types, upgrade phpunit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
         "sebastian/exporter": "^3.1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^6.5"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
          timeoutForSmallTests="1"
          timeoutForMediumTests="10"
          timeoutForLargeTests="60"
+         beStrictAboutTestsThatDoNotTestAnything="false"
          verbose="false">
   <testsuites>
     <testsuite name="test suite.">

--- a/tests/PhockitoBuiltinsTest.php
+++ b/tests/PhockitoBuiltinsTest.php
@@ -3,7 +3,7 @@
 // Include Phockito
 require_once(dirname(dirname(__FILE__)) . '/Phockito.php');
 
-class PhockitoBuiltinsTest extends PHPUnit_Framework_TestCase {
+class PhockitoBuiltinsTest extends PHPUnit\Framework\TestCase {
 
 	/** Test creation of mock class for builtins **/
 

--- a/tests/PhockitoGlobalsTest.php
+++ b/tests/PhockitoGlobalsTest.php
@@ -10,7 +10,7 @@ class PhockitoGlobalsTest_MockMe {
 
 /** And the tests themselves */
 
-class PhockitoGlobalsTest extends PHPUnit_Framework_TestCase {
+class PhockitoGlobalsTest extends PHPUnit\Framework\TestCase {
 
 	function testCanBuildMock() {
 		$mock = mock('PhockitoGlobalsTest_MockMe');

--- a/tests/PhockitoHamcrestTest.php
+++ b/tests/PhockitoHamcrestTest.php
@@ -12,7 +12,7 @@ class PhockitoHamcrestTest_MockMe {
 
 class PhockitoHamcrestTest_PassMe {}
 
-class PhockitoHamcrestTest extends PHPUnit_Framework_TestCase {
+class PhockitoHamcrestTest extends PHPUnit\Framework\TestCase {
 
 	/** Test stubbing **/
 

--- a/tests/PhockitoHamcrestTypeBridgeTest.php
+++ b/tests/PhockitoHamcrestTypeBridgeTest.php
@@ -23,7 +23,7 @@ class PhockitoHamcrestTypeBridgeTest_PassMe_MatcherMethods {
 	public function matches($item) { throw new Exception('Base method matches was called'); }
 }
 
-class PhockitoHamcrestTypeBridgeTest extends PHPUnit_Framework_TestCase {
+class PhockitoHamcrestTypeBridgeTest extends PHPUnit\Framework\TestCase {
     function testCanStubUsingMatchersForTypeHintedObjectArguments() {
         $mock = Phockito::mock('PhockitoHamcrestTypeBridgeTest_MockMe');
 
@@ -47,7 +47,7 @@ class PhockitoHamcrestTypeBridgeTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedException PHPUnit\Framework\Error\Error
 	 * @expectedExceptionCode E_USER_ERROR
 	 * @expectedExceptionMessage Can't mock non-existent class NotAClass
 	 */
@@ -61,7 +61,7 @@ class PhockitoHamcrestTypeBridgeTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedException PHPUnit\Framework\Error\Error
 	 * @expectedExceptionCode E_USER_ERROR
 	 */
 	function testCannotBridgeFinalType() {

--- a/tests/PhockitoNamespaceTest_Actual.php
+++ b/tests/PhockitoNamespaceTest_Actual.php
@@ -54,7 +54,7 @@ namespace org\phockito\tests {
 
 namespace {
 
-	class PhockitoNamespaceTest extends PHPUnit_Framework_TestCase {
+	class PhockitoNamespaceTest extends PHPUnit\Framework\TestCase {
 
 		function testCanMockNamespacedClass() {
 			$mock = Phockito::mock('\org\phockito\tests\PhockitoNamespaceTest_MockMe');

--- a/tests/PhockitoOverloadedCallTest.php
+++ b/tests/PhockitoOverloadedCallTest.php
@@ -6,7 +6,7 @@ class PhockitoOverloadedCallTest_OverloadedCall {
 	function __call($name, $args) { return $name; }
 }
 
-class PhockitoOverloadedCallTest extends PHPUnit_Framework_TestCase {
+class PhockitoOverloadedCallTest extends PHPUnit\Framework\TestCase {
 
 	function testMockingCall() {
 		$mock = Phockito::mock('PhockitoOverloadedCallTest_OverloadedCall');

--- a/tests/PhockitoResetTest.php
+++ b/tests/PhockitoResetTest.php
@@ -12,7 +12,7 @@ class PhockitoResetTest_MockMe {
 
 /** And the tests themselves */
 
-class PhockitoResetTest extends PHPUnit_Framework_TestCase {
+class PhockitoResetTest extends PHPUnit\Framework\TestCase {
 
 	function testCanResetStubbedResults() {
 		$mock = Phockito::mock('PhockitoResetTest_MockMe');

--- a/tests/PhockitoSilverStripeTest.php
+++ b/tests/PhockitoSilverStripeTest.php
@@ -26,7 +26,7 @@ $_PSST_ALL_CLASSES = array(
 	)
 );
 
-class PhockitoSilverStripeTest extends PHPUnit_Framework_TestCase {
+class PhockitoSilverStripeTest extends PHPUnit\Framework\TestCase {
 
 	static $orig_type_registrar;
 	static $orig_all_classes;

--- a/tests/PhockitoSpiesTest.php
+++ b/tests/PhockitoSpiesTest.php
@@ -11,7 +11,7 @@ class PhockitoSpiesTest_MockMe {
 	function Baz($response) { return $response; }
 }
 
-class PhockitoSpiesTest extends PHPUnit_Framework_TestCase {
+class PhockitoSpiesTest extends PHPUnit\Framework\TestCase {
 
 	/** Test stubbing **/
 

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -55,7 +55,7 @@ class PhockitoTest_FooHasIntegerReturn { function Foo() : int { } }
 
 /** And the tests themselves */
 
-class PhockitoTest extends PHPUnit_Framework_TestCase {
+class PhockitoTest extends PHPUnit\Framework\TestCase {
 
 	static function setUpBeforeClass() {
 		Phockito_VerifyBuilder::$exception_class = 'PhockitoTest_VerificationFailure';
@@ -280,7 +280,7 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * The raised error will be wrapped in an exception by PHPUnit
-	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedException PHPUnit\Framework\Error\Error
 	 * @expectedExceptionCode E_USER_ERROR
 	 */
 	function testCannotUseThenWithoutAPreviousAction() {
@@ -290,7 +290,7 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * The raised error will be wrapped in an exception by PHPUnit
-	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedException PHPUnit\Framework\Error\Error
 	 * @expectedExceptionCode E_USER_ERROR
 	 */
 	function testUnknownStubbingActionThrowsAnError() {
@@ -300,7 +300,7 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * The raised error will be wrapped in an exception by PHPUnit
-	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedException PHPUnit\Framework\Error\Error
 	 * @expectedExceptionCode E_USER_ERROR
 	 */
 	function testProvidingTooFewArgumentsToStubbingActionThrowsAnError() {
@@ -310,7 +310,7 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * The raised error will be wrapped in an exception by PHPUnit
-	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedException PHPUnit\Framework\Error\Error
 	 * @expectedExceptionCode E_USER_ERROR
 	 */
 	function testProvidingTooManyArgumentsToStubbingActionThrowsAnError() {
@@ -483,7 +483,7 @@ EOT;
 	}
 
 	/**
-	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedException PHPUnit\Framework\Error\Error
 	 * @expectedExceptionCode E_USER_ERROR
 	 */
 	function testCannotMockFinalClass() {

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -51,6 +51,8 @@ class PhockitoTest_FooReturnsByReference_Implements implements PhockitoTest_Mock
 class PhockitoTest_VerificationFailure extends Exception {}
 class PhockitoTest_StubResponse extends Exception {}
 
+class PhockitoTest_FooHasIntegerReturn { function Foo() : int { } }
+
 /** And the tests themselves */
 
 class PhockitoTest extends PHPUnit_Framework_TestCase {
@@ -96,6 +98,32 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 		$mock = Phockito::mock('PhockitoTest_FooHasIntegerDefaultArgument');
 		$this->assertNull($mock->Foo());
 		$this->assertNull($mock->Foo(1));
+	}
+
+	function testCanCreateMockMethodWithIntegerReturnChecksType() {
+		$mock = Phockito::mock('PhockitoTest_FooHasIntegerReturn');
+		try {
+			Phockito::when($mock)->Foo(2)->return('x');
+			$this->fail('should throw');
+		} catch (TypeError $e) {
+			$this->assertSame('The mocked return value for method PhockitoTest_FooHasIntegerReturn->Foo was string, but the return type must be int', $e->getMessage());
+		}
+	}
+
+	function testCanCreateMockMethodWithIntegerReturnChecksNullType() {
+		$mock = Phockito::mock('PhockitoTest_FooHasIntegerReturn');
+		try {
+			Phockito::when($mock)->Foo(2)->return(null);
+			$this->fail('should throw');
+		} catch (TypeError $e) {
+			$this->assertSame('The mocked return value for method PhockitoTest_FooHasIntegerReturn->Foo was null, but the return type must be int', $e->getMessage());
+		}
+	}
+
+	function testCanCreateMockMethodWithIntegerReturnAcceptsValidType() {
+		$mock = Phockito::mock('PhockitoTest_FooHasIntegerReturn');
+		Phockito::when($mock)->Foo(2)->return(3);
+		$this->assertSame(3, $mock->Foo(2));
 	}
 
 	function testCanCreateMockMethodWithArrayDefaultArgument() {

--- a/tests/PhockitoTostringTest.php
+++ b/tests/PhockitoTostringTest.php
@@ -12,7 +12,7 @@ class PhockitoTostringTest_MockWithoutToString {
 	function Foo() { }
 }
 
-class PhockitoToStringTest extends PHPUnit_Framework_TestCase {
+class PhockitoToStringTest extends PHPUnit\Framework\TestCase {
 
 	function testCanMockAndOverrideExistingToString() {
 		$mock = Phockito::mock('PhockitoTostringTest_MockWithToString');


### PR DESCRIPTION
This change has been verified in a large codebase using this library.